### PR TITLE
use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN npm cache clean --force
 ENV NODE_ENV="production"
 COPY . .
 EXPOSE 3000
-CMD [ "npm", "start" ]
+ENTRYPOINT [ "npm", "start" ]


### PR DESCRIPTION
Using entrypoint enables to set custom arguments when creating a container using the `Command` option. 